### PR TITLE
Add Excel export for scenario summary results

### DIFF
--- a/HEC.FDA.View/Results/ScenarioDamageSummary.xaml
+++ b/HEC.FDA.View/Results/ScenarioDamageSummary.xaml
@@ -4,14 +4,17 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:HEC.FDA.View.Results"
-             xmlns:util="clr-namespace:HEC.FDA.View.Utilities"
              xmlns:utilVM="clr-namespace:HEC.FDA.ViewModel.Utilities;assembly=HEC.FDA.ViewModel"
              xmlns:twp="clr-namespace:HEC.FDA.View.TableWithPlot"
              xmlns:results="clr-namespace:HEC.FDA.ViewModel.Results;assembly=HEC.FDA.ViewModel"
+             xmlns:cmds="clr-namespace:HEC.FDA.View.Commands"
              d:DataContext="{d:DesignInstance Type=results:ScenarioDamageSummaryVM}"
              mc:Ignorable="d"
              d:DesignHeight="450"
              d:DesignWidth="800">
+  <UserControl.Resources>
+    <cmds:CloseCommand x:Key="closeCommand" />
+  </UserControl.Resources>
   <Grid>
 
     <Grid.RowDefinitions>
@@ -395,6 +398,26 @@
 
       </Grid>
     </ScrollViewer>
-    <util:CloseControl Grid.Row="1" />
+    <Grid Grid.Row="1">
+      <StackPanel Orientation="Horizontal"
+                  HorizontalAlignment="Right"
+                  Margin="0,0,5,0">
+        <Button Content="Export"
+                Margin="5,5,2,5"
+                Width="60"
+                Height="22"
+                Command="{Binding ExportToExcelCommand}" />
+        <Button Content="Close"
+                Margin="2,5,5,5"
+                Width="40"
+                Height="22"
+                IsCancel="True"
+                Command="{Binding Source={StaticResource closeCommand}}">
+          <Button.CommandParameter>
+            <Binding RelativeSource="{RelativeSource FindAncestor, AncestorType=Window}" />
+          </Button.CommandParameter>
+        </Button>
+      </StackPanel>
+    </Grid>
   </Grid>
 </UserControl>

--- a/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
+++ b/HEC.FDA.ViewModel/HEC.FDA.ViewModel.csproj
@@ -6,16 +6,17 @@
 		<RootNamespace>HEC.FDA.ViewModel</RootNamespace>
 	</PropertyGroup>
 	
-	<ItemGroup>
-		<ProjectReference Include="..\HEC.FDA.Importer\HEC.FDA.Importer.csproj" />
-		<ProjectReference Include="..\HEC.FDA.Model\HEC.FDA.Model.csproj" />
-		<ProjectReference Include="..\HEC.MVVMFramework.ViewModel\HEC.MVVMFramework.ViewModel.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="HEC.RAS.Visual.Observables" Version="0.1.0.1554-dev" />		
-		<PackageReference Include="PlottingLibrary2D" Version="1.0.0-beta-gdc08aa8621" />
-		<PackageReference Include="OxyPlot.Wpf" Version="2.1.2" />
-	</ItemGroup>
+        <ItemGroup>
+                <ProjectReference Include="..\HEC.FDA.Importer\HEC.FDA.Importer.csproj" />
+                <ProjectReference Include="..\HEC.FDA.Model\HEC.FDA.Model.csproj" />
+                <ProjectReference Include="..\HEC.MVVMFramework.ViewModel\HEC.MVVMFramework.ViewModel.csproj" />
+        </ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+                <PackageReference Include="ClosedXML" Version="0.103.3" />
+                <PackageReference Include="HEC.RAS.Visual.Observables" Version="0.1.0.1554-dev" />
+                <PackageReference Include="PlottingLibrary2D" Version="1.0.0-beta-gdc08aa8621" />
+                <PackageReference Include="OxyPlot.Wpf" Version="2.1.2" />
+        </ItemGroup>
 
 </Project>

--- a/HEC.FDA.ViewModel/Results/ScenarioDamageSummaryVM.cs
+++ b/HEC.FDA.ViewModel/Results/ScenarioDamageSummaryVM.cs
@@ -1,10 +1,16 @@
-﻿using HEC.CS.Collections;
+using ClosedXML.Excel;
+using HEC.CS.Collections;
 using HEC.FDA.Model.metrics;
 using HEC.FDA.ViewModel.ImpactAreaScenario;
 using HEC.FDA.ViewModel.Saving;
+using Microsoft.Win32;
+using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 using System.Linq;
+using System.Windows;
+using System.Windows.Input;
 
 namespace HEC.FDA.ViewModel.Results
 {
@@ -17,17 +23,21 @@ namespace HEC.FDA.ViewModel.Results
         public CustomObservableCollection<AssuranceOfAEPRowItem> AssuranceOfAEPRows { get; } = [];
         public CustomObservableCollection<ScenarioDamCatRowItem> DamCatRows { get; } = [];
 
+        public ICommand ExportToExcelCommand { get; }
+
         public ScenarioDamageSummaryVM(List<IASElement> selectedScenarioElems)
         {
+            ExportToExcelCommand = new CommandHandler(ExportToExcel, true);
+
             List<IASElement> allElements = StudyCache.GetChildElementsOfType<IASElement>();
 
             foreach (IASElement element in allElements)
             {
                 SelectableChildElement selectElem = new SelectableChildElement(element);
                 SelectableElements.Add(selectElem);
-                //the selectable elements are selected by default. We want to toggle all the elements that 
+                //the selectable elements are selected by default. We want to toggle all the elements that
                 //aren't in the passed in list off.
-                if(!selectedScenarioElems.Contains(element))
+                if (!selectedScenarioElems.Contains(element))
                 {
                     selectElem.IsSelected = false;
                 }
@@ -40,6 +50,8 @@ namespace HEC.FDA.ViewModel.Results
 
         public ScenarioDamageSummaryVM()
         {
+            ExportToExcelCommand = new CommandHandler(ExportToExcel, true);
+
             List<IASElement> allElements = StudyCache.GetChildElementsOfType<IASElement>();
 
             foreach (IASElement element in allElements)
@@ -87,7 +99,6 @@ namespace HEC.FDA.ViewModel.Results
         private void LoadTables()
         {
             List<IASElement> elems = GetSelectedElements();
-            List<ScenarioDamCatRowItem> damCatRows = new List<ScenarioDamCatRowItem>();
             Rows.Clear();
             PerformanceRows.Clear();
             AssuranceOfAEPRows.Clear();
@@ -98,7 +109,7 @@ namespace HEC.FDA.ViewModel.Results
                 DamCatRows.AddRange(ScenarioDamCatRowItem.CreateScenarioDamCatRowItems(element));
                 List<ImpactAreaScenarioResults> resultsList = element.Results.ResultsList;
                 foreach (ImpactAreaScenarioResults impactAreaScenarioResults in resultsList)
-                { 
+                {
                     int iasID = impactAreaScenarioResults.ImpactAreaID;
                     SpecificIAS ias = element.SpecificIASElements.Where(ias => ias.ImpactAreaID == iasID).First();
 
@@ -119,14 +130,157 @@ namespace HEC.FDA.ViewModel.Results
         private List<IASElement> GetSelectedElements()
         {
             List<IASElement> selectedElements = new List<IASElement>();
-            foreach(SelectableChildElement selectElem in SelectableElements)
+            foreach (SelectableChildElement selectElem in SelectableElements)
             {
-                if(selectElem.IsSelected)
+                if (selectElem.IsSelected)
                 {
                     selectedElements.Add(selectElem.Element as IASElement);
                 }
             }
             return selectedElements;
+        }
+
+        private void ExportToExcel()
+        {
+            if (!Rows.Any() && !DamCatRows.Any() && !PerformanceRows.Any() && !AssuranceOfAEPRows.Any())
+            {
+                MessageBox.Show("There are no results available to export.", "Export Scenario Summary Results", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            SaveFileDialog dialog = new()
+            {
+                Title = "Export Scenario Summary Results",
+                Filter = "Excel Workbook (*.xlsx)|*.xlsx",
+                FileName = "ScenarioSummaryResults.xlsx",
+                AddExtension = true,
+                DefaultExt = ".xlsx"
+            };
+
+            bool? dialogResult = dialog.ShowDialog();
+            if (dialogResult != true || string.IsNullOrWhiteSpace(dialog.FileName))
+            {
+                return;
+            }
+
+            try
+            {
+                using XLWorkbook workbook = new();
+                AddExpectedAnnualDamageTable(workbook);
+                AddDamageByCategoryTable(workbook);
+                AddPerformanceTable(workbook);
+                AddAssuranceOfAepTable(workbook);
+
+                workbook.SaveAs(dialog.FileName);
+                MessageBox.Show($"Scenario summary results exported to:{Environment.NewLine}{dialog.FileName}", "Export Complete", MessageBoxButton.OK, MessageBoxImage.Information);
+            }
+            catch (IOException ioEx)
+            {
+                MessageBox.Show($"The export file could not be created. Please close any application using the file and try again.{Environment.NewLine}{ioEx.Message}", "Export Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"An unexpected error occurred while exporting the results.{Environment.NewLine}{ex.Message}", "Export Failed", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void AddExpectedAnnualDamageTable(XLWorkbook workbook)
+        {
+            DataTable table = new("Expected Annual Damage");
+            table.Columns.Add("Scenario Name");
+            table.Columns.Add("Analysis Year");
+            table.Columns.Add("Impact Area");
+            table.Columns.Add("Mean EAD", typeof(double));
+            table.Columns.Add("25th Percentile EAD", typeof(double));
+            table.Columns.Add("50th Percentile EAD", typeof(double));
+            table.Columns.Add("75th Percentile EAD", typeof(double));
+
+            foreach (ScenarioDamageRowItem row in Rows)
+            {
+                table.Rows.Add(row.Name, row.AnalysisYear, row.ImpactArea, row.Mean, row.Point75, row.Point5, row.Point25);
+            }
+
+            InsertTable(workbook, table, "EAD Summary", "EAD_Summary");
+        }
+
+        private void AddDamageByCategoryTable(XLWorkbook workbook)
+        {
+            DataTable table = new("Expected Annual Damage by Category");
+            table.Columns.Add("Scenario Name");
+            table.Columns.Add("Analysis Year");
+            table.Columns.Add("Impact Area");
+            table.Columns.Add("Damage Category");
+            table.Columns.Add("Asset Category");
+            table.Columns.Add("Mean EAD", typeof(double));
+
+            foreach (ScenarioDamCatRowItem row in DamCatRows)
+            {
+                table.Rows.Add(row.Name, row.AnalysisYear, row.ImpactAreaName, row.DamCat, row.AssetCat, row.MeanDamage);
+            }
+
+            InsertTable(workbook, table, "EAD by Category", "EAD_By_Category");
+        }
+
+        private void AddPerformanceTable(XLWorkbook workbook)
+        {
+            DataTable table = new("Performance Metrics");
+            table.Columns.Add("Scenario Name");
+            table.Columns.Add("Analysis Year");
+            table.Columns.Add("Impact Area");
+            table.Columns.Add("Threshold Type");
+            table.Columns.Add("Threshold Value", typeof(double));
+            table.Columns.Add("Mean AEP", typeof(double));
+            table.Columns.Add("Median AEP", typeof(double));
+            table.Columns.Add("Long-Term 10", typeof(double));
+            table.Columns.Add("Long-Term 30", typeof(double));
+            table.Columns.Add("Long-Term 50", typeof(double));
+            table.Columns.Add("Assurance 0.1", typeof(double));
+            table.Columns.Add("Assurance 0.04", typeof(double));
+            table.Columns.Add("Assurance 0.02", typeof(double));
+            table.Columns.Add("Assurance 0.01", typeof(double));
+            table.Columns.Add("Assurance 0.004", typeof(double));
+            table.Columns.Add("Assurance 0.002", typeof(double));
+
+            foreach (ScenarioPerformanceRowItem row in PerformanceRows)
+            {
+                table.Rows.Add(row.Name, row.AnalysisYear, row.ImpactArea, row.ThresholdType, row.ThresholdValue, row.Mean, row.Median, row.LongTerm10, row.LongTerm30, row.LongTerm50, row.Threshold1, row.Threshold04, row.Threshold02, row.Threshold01, row.Threshold004, row.Threshold002);
+            }
+
+            InsertTable(workbook, table, "Performance", "Performance_Metrics");
+        }
+
+        private void AddAssuranceOfAepTable(XLWorkbook workbook)
+        {
+            DataTable table = new("Assurance of AEP");
+            table.Columns.Add("Scenario Name");
+            table.Columns.Add("Analysis Year");
+            table.Columns.Add("Impact Area");
+            table.Columns.Add("Threshold Type");
+            table.Columns.Add("Threshold Value", typeof(double));
+            table.Columns.Add("Mean AEP", typeof(double));
+            table.Columns.Add("Median AEP", typeof(double));
+            table.Columns.Add("AEP with 90% Assurance", typeof(double));
+            table.Columns.Add("AEP 0.1", typeof(double));
+            table.Columns.Add("AEP 0.04", typeof(double));
+            table.Columns.Add("AEP 0.02", typeof(double));
+            table.Columns.Add("AEP 0.01", typeof(double));
+            table.Columns.Add("AEP 0.004", typeof(double));
+            table.Columns.Add("AEP 0.002", typeof(double));
+
+            foreach (AssuranceOfAEPRowItem row in AssuranceOfAEPRows)
+            {
+                table.Rows.Add(row.Name, row.AnalysisYear, row.ImpactArea, row.ThresholdType, row.ThresholdValue, row.Mean, row.Median, row.NinetyPercentAssurance, row.AEP1, row.AEP04, row.AEP02, row.AEP01, row.AEP004, row.AEP002);
+            }
+
+            InsertTable(workbook, table, "AEP Assurance", "AEP_Assurance");
+        }
+
+        private static void InsertTable(XLWorkbook workbook, DataTable table, string worksheetName, string tableName)
+        {
+            var worksheet = workbook.Worksheets.Add(worksheetName);
+            var xlTable = worksheet.Cell(1, 1).InsertTable(table, tableName);
+            xlTable.Theme = XLTableTheme.TableStyleMedium2;
+            worksheet.Columns().AdjustToContents();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an Export button alongside Close in the Scenario Summary Results view
- implement Excel export of scenario summary datasets with dedicated tables using ClosedXML
- reference the ClosedXML package to support workbook creation

## Testing
- `dotnet restore` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caf8a250b08330bf04fcd1e129229a